### PR TITLE
Add glthubs.net to database

### DIFF
--- a/input-source/domains/public-domain-additions.txt
+++ b/input-source/domains/public-domain-additions.txt
@@ -1,0 +1,1 @@
+glthubs.net


### PR DESCRIPTION
I originally received a link to this domain via a phishing email. Their SSL seems to be via Cloudflare, so I will attempt to report this there, but am reporting to this database in the meantime.