### PR TITLE
Dead domain additioncoronation.com

### DIFF
--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -352,7 +352,6 @@ recoverrryasitalycovid-19.xyz
 riddoffcovid19.xyz
 rxcovid.com
 schooluniformtrading.com.au
-securitycovid19.online
 seliconos.3utilities.com
 srocorona.com
 stopcorona.xyz

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -325,7 +325,6 @@ localcoronavirus.com
 lopinavirandritonavircoronavirus.com
 loveinthetimeofcoronavirus.tips
 mapadocoronavirus.com
-mycoronaria.com
 mycovid19care.com
 neumaticoscoronado.com
 newscoronavirus.xyz

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -286,7 +286,6 @@ covidquarantine.com
 covidrid.com
 dating4free.us
 dating4sex.us
-dewakartu.info
 dewarejeki.info
 disabilitylawyercorona.com
 disneyscoronadospringsresort.review

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -142,7 +142,6 @@ coronavirus-statistics-710b6.firebaseio.com
 coronavirus-testing.com
 coronavirus-tracker-api.herokuapp.com
 coronavirus-treatment.today
-coronavirus-update.info
 coronavirus-update.ru
 coronavirus-update.today
 coronavirus.app

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -286,7 +286,6 @@ covidquarantine.com
 covidrid.com
 dating4free.us
 dating4sex.us
-disneyscoronadospringsresort.review
 dizcorona.com
 doihavecoronaviruscovid19.com
 doihavecovid-19.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -322,7 +322,6 @@ kristom.hopto.org
 letsbeatcovid19.com
 lgin.msa.trafficmanager.net
 localcoronavirus.com
-loewscoronadobayresort.review
 lopinavirandritonavircoronavirus.com
 loveinthetimeofcoronavirus.tips
 mapadocoronavirus.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -284,7 +284,6 @@ covidmaskon.com
 covidpacka.site
 covidquarantine.com
 covidrid.com
-covidsfthesuh.co.uk
 currencycoronary.net
 dating4free.us
 dating4sex.us

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -319,7 +319,6 @@ italycovid-19.site
 jocoly.esvnpe.com
 kbfvzoboss.bid
 kristom.hopto.org
-leticiareyescorona2.com
 letsbeatcovid19.com
 lgin.msa.trafficmanager.net
 localcoronavirus.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -89,7 +89,6 @@ coronafile.com
 coronaginincubation.bid
 coronaguide.bid
 coronahealth.news
-coronalhandyman.info
 coronalightwideopen.top
 coronaliqua.ml
 coronaliqua.tk

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -401,7 +401,6 @@ wuhancoronavirustracker-693c1.firebaseio.com
 www.0202.com.tw
 www.coronavirus.app
 www.ggpht.ml
-www.kryll.ug
 wy.adyboh.com
 xml.lgin.msa.trafficmanager.net
 ziaco-corona.work

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -103,7 +103,6 @@ coronasolve.xyz
 coronasushi.com.de
 coronate.ga
 coronatec.com.br
-coronationfunction.site
 coronationgulf.tk
 coronations.in
 coronatoolseurope.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -148,7 +148,6 @@ coronavirus.app
 coronavirus.cc
 coronavirus.computer
 coronavirus.investments
-coronavirus.netfunnel.co.kr
 coronavirus.oss-accelerate.aliyuncs.com
 coronavirus.schule
 coronavirus.toys

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -335,7 +335,6 @@ officialcoronavirus19.com
 online-coronavirus-268608.firebaseio.com
 onthefx.com
 ovejascoronadas.com
-pacificovideos.top
 pandemiccoronavirusremove.us
 pandemiscoronasurviv.us
 pandjecorona.us

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -89,7 +89,6 @@ coronafile.com
 coronaginincubation.bid
 coronaguide.bid
 coronahealth.news
-coronalightwideopen.top
 coronaliqua.ml
 coronaliqua.tk
 coronalists.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -316,7 +316,6 @@ impots-covid19.com
 insiderppe.cloudapp.net
 ipv4.login.msa.akadns6.net
 italycovid-19.site
-jayalbertandassociates.com
 jocoly.esvnpe.com
 josephcoronado.site
 kbfvzoboss.bid

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -289,7 +289,6 @@ dating4sex.us
 doihavecoronaviruscovid19.com
 doihavecovid-19.com
 dopconverion.ru
-dracovid.ru
 drhuzaifa.com
 dw.adyboh.com
 easytogets.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -284,7 +284,6 @@ covidmaskon.com
 covidpacka.site
 covidquarantine.com
 covidrid.com
-currencycoronary.net
 dating4free.us
 dating4sex.us
 dewakartu.info

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -105,7 +105,6 @@ coronate.ga
 coronatec.com.br
 coronationgulf.tk
 coronatoolseurope.com
-coronavid19.net
 coronavideo3.tk
 coronavirss.rest
 coronavirus-2019.firebaseio.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -352,7 +352,6 @@ recoverrryasitalycovid-19.xyz
 riddoffcovid19.xyz
 rxcovid.com
 schooluniformtrading.com.au
-securitebd38a-stop7760a-virusad837-service-corona4a2d9-21343.com
 securitycovid19.online
 seliconos.3utilities.com
 srocorona.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -92,7 +92,6 @@ coronahealth.news
 coronaliqua.ml
 coronaliqua.tk
 coronalists.com
-coronaltab.info
 coronamalta.com
 coronamarks.work
 coronamaskmap.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -286,7 +286,6 @@ covidquarantine.com
 covidrid.com
 dating4free.us
 dating4sex.us
-disabilitylawyercorona.com
 disneyscoronadospringsresort.review
 dizcorona.com
 doihavecoronaviruscovid19.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -99,7 +99,6 @@ coronanewssupport.com
 coronaorsemiproof.bid
 coronaperformancemotors.com
 coronaplay.ru
-coronarycareunit.us
 coronaryyo.co.kr
 coronasdeflores.cl
 coronasolve.xyz

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -300,7 +300,6 @@ feb.kkooppt.com
 feenixlanguage.com
 fightcoronavirus.life
 flutter-covid19.firebaseio.com
-freetospeak.me
 fundacionayudacoronavirus.xyz
 gaticovideo.tk
 getcoronavirusalert.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -89,7 +89,6 @@ coronafile.com
 coronaginincubation.bid
 coronaguide.bid
 coronahealth.news
-coronainsuranceinc.com
 coronalhandyman.info
 coronalightwideopen.top
 coronaliqua.ml

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -348,7 +348,6 @@ postcovid19.world
 prevenirecoronavirus.info
 psicmaggiecorona.com
 psico-pedagogiaespacovida.com.br
-rackscorona.com
 recoverrryasitalycovid-19.xyz
 recovidapp.com
 redditdating.us

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -205,7 +205,6 @@ coronavirusremotepatientobservation.com
 coronaviruss.casa
 coronaviruss.ir
 coronavirussen.com
-coronavirussickleave.com
 coronavirusstatisticsandinformation.com
 coronavirusstatus.space
 coronavirussymptomchecker.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -105,7 +105,6 @@ coronate.ga
 coronatec.com.br
 coronationgulf.tk
 coronatoolseurope.com
-coronatowel.space
 coronavid19.net
 coronavideo3.tk
 coronavirss.rest

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -92,7 +92,6 @@ coronahealth.news
 coronaliqua.ml
 coronaliqua.tk
 coronalists.com
-coronalsupport.info
 coronaltab.info
 coronamalta.com
 coronamarks.work

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -92,7 +92,6 @@ coronahealth.news
 coronaliqua.ml
 coronaliqua.tk
 coronalists.com
-coronalse.in
 coronalsupport.info
 coronaltab.info
 coronamalta.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -99,7 +99,6 @@ coronanewssupport.com
 coronaorsemiproof.bid
 coronaperformancemotors.com
 coronaplay.ru
-coronasdeflores.cl
 coronasolve.xyz
 coronasushi.com.de
 coronate.ga

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -260,7 +260,6 @@ covid19kit.online
 covid19lascruces.com
 covid19map-269302.firebaseio.com
 covid19mayhem.com
-covid19mc.com
 covid19patients.world
 covid19plans.com
 covid19plasma.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -99,7 +99,6 @@ coronanewssupport.com
 coronaorsemiproof.bid
 coronaperformancemotors.com
 coronaplay.ru
-coronaryassociation.co.za
 coronarycareunit.biz
 coronarycareunit.us
 coronaryyo.co.kr

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -99,7 +99,6 @@ coronanewssupport.com
 coronaorsemiproof.bid
 coronaperformancemotors.com
 coronaplay.ru
-coronaproducecompare11.info
 coronarocks.com
 coronaryassociation.co.za
 coronarycareunit.biz

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -126,7 +126,6 @@ coronavirus-eba7a.firebaseio.com
 coronavirus-gov.in
 coronavirus-homeschool.com
 coronavirus-info-chatbot.com
-coronavirus-latest-update.info
 coronavirus-live-update.com
 coronavirus-live-updates.com
 coronavirus-map.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -99,7 +99,6 @@ coronanewssupport.com
 coronaorsemiproof.bid
 coronaperformancemotors.com
 coronaplay.ru
-coronarycareunit.biz
 coronarycareunit.us
 coronaryyo.co.kr
 coronasdeflores.cl

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -92,7 +92,6 @@ coronahealth.news
 coronaliqua.ml
 coronaliqua.tk
 coronalists.com
-coronals.stream
 coronalse.in
 coronalsupport.info
 coronaltab.info

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -286,7 +286,6 @@ covidquarantine.com
 covidrid.com
 dating4free.us
 dating4sex.us
-dewarejeki.info
 disabilitylawyercorona.com
 disneyscoronadospringsresort.review
 dizcorona.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -319,7 +319,6 @@ italycovid-19.site
 jocoly.esvnpe.com
 kbfvzoboss.bid
 kristom.hopto.org
-kryll.ug
 leticiareyescorona2.com
 letsbeatcovid19.com
 lgin.msa.trafficmanager.net

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -325,7 +325,6 @@ localcoronavirus.com
 lopinavirandritonavircoronavirus.com
 loveinthetimeofcoronavirus.tips
 mapadocoronavirus.com
-mmedicalcovid19.com
 mycoronaria.com
 mycovid19care.com
 neumaticoscoronado.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -305,7 +305,6 @@ gaticovideo.tk
 getcoronavirusassistance.com
 ggpht.ml
 gocycle.com.au
-granparkecovidalancamento.com.br
 healing-yui223.com
 hoosiercoronavirus.com
 hovafmd.ddns.net

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -349,7 +349,6 @@ prevenirecoronavirus.info
 psicmaggiecorona.com
 psico-pedagogiaespacovida.com.br
 recoverrryasitalycovid-19.xyz
-redditdating.us
 reentercoronagraph.co.kr
 riddoffcovid19.xyz
 rxcovid.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -126,7 +126,6 @@ coronavirus-eba7a.firebaseio.com
 coronavirus-gov.in
 coronavirus-homeschool.com
 coronavirus-info-chatbot.com
-coronavirus-latest-update.com
 coronavirus-latest-update.info
 coronavirus-live-update.com
 coronavirus-live-updates.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -326,7 +326,6 @@ lopinavirandritonavircoronavirus.com
 loveinthetimeofcoronavirus.tips
 mapadocoronavirus.com
 mycovid19care.com
-neumaticoscoronado.com
 newscoronavirus.xyz
 newvity.com
 novelcoronavirus.report

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -325,7 +325,6 @@ localcoronavirus.com
 lopinavirandritonavircoronavirus.com
 loveinthetimeofcoronavirus.tips
 mapadocoronavirus.com
-mexicovida.de
 mmedicalcovid19.com
 mycoronaria.com
 mycovid19care.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -298,7 +298,6 @@ fashioncoronaviruspatientzero.cloud
 fe-by01p-msa.trafficmanager.net
 feb.kkooppt.com
 feenixlanguage.com
-fercoronado.com
 fightcoronavirus.life
 flutter-covid19.firebaseio.com
 freetospeak.me

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -126,7 +126,6 @@ coronavirus-eba7a.firebaseio.com
 coronavirus-gov.in
 coronavirus-homeschool.com
 coronavirus-info-chatbot.com
-coronavirus-live-update.com
 coronavirus-live-updates.com
 coronavirus-map.com
 coronavirus-maps.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -325,7 +325,6 @@ localcoronavirus.com
 lopinavirandritonavircoronavirus.com
 loveinthetimeofcoronavirus.tips
 mapadocoronavirus.com
-matthewcoronagoldstein.icu
 mexicovida.de
 mmedicalcovid19.com
 mycoronaria.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -349,7 +349,6 @@ prevenirecoronavirus.info
 psicmaggiecorona.com
 psico-pedagogiaespacovida.com.br
 recoverrryasitalycovid-19.xyz
-reentercoronagraph.co.kr
 riddoffcovid19.xyz
 rxcovid.com
 schooluniformtrading.com.au

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -320,7 +320,6 @@ jocoly.esvnpe.com
 kbfvzoboss.bid
 kristom.hopto.org
 kryll.ug
-leakdetectioncorona.com
 leticiareyescorona2.com
 letsbeatcovid19.com
 lgin.msa.trafficmanager.net

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -104,7 +104,6 @@ coronasushi.com.de
 coronate.ga
 coronatec.com.br
 coronationgulf.tk
-coronations.in
 coronatoolseurope.com
 coronatowel.space
 coronavid19.net

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -99,7 +99,6 @@ coronanewssupport.com
 coronaorsemiproof.bid
 coronaperformancemotors.com
 coronaplay.ru
-coronaryyo.co.kr
 coronasdeflores.cl
 coronasolve.xyz
 coronasushi.com.de

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -375,7 +375,6 @@ survivecovid19.tk
 survivvruscorona.us
 testcorona.se
 theanticorona.com
-thecoronahomeexpert.com
 thecoronanet.com
 thevillageinncoronado.review
 thumbeks.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -99,7 +99,6 @@ coronanewssupport.com
 coronaorsemiproof.bid
 coronaperformancemotors.com
 coronaplay.ru
-coronarocks.com
 coronaryassociation.co.za
 coronarycareunit.biz
 coronarycareunit.us

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -376,7 +376,6 @@ survivvruscorona.us
 testcorona.se
 theanticorona.com
 thecoronanet.com
-thevillageinncoronado.review
 thumbeks.com
 tncovid19.com
 tracie-coronado.us

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -317,7 +317,6 @@ insiderppe.cloudapp.net
 ipv4.login.msa.akadns6.net
 italycovid-19.site
 jocoly.esvnpe.com
-josephcoronado.site
 kbfvzoboss.bid
 kristom.hopto.org
 kryll.ug

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -378,7 +378,6 @@ theanticorona.com
 thecoronanet.com
 thumbeks.com
 tncovid19.com
-tracie-coronado.us
 treatmentcovid2019.com
 ubercoronavirusprotection.com
 uberdoctorcoronavirus.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -349,7 +349,6 @@ prevenirecoronavirus.info
 psicmaggiecorona.com
 psico-pedagogiaespacovida.com.br
 recoverrryasitalycovid-19.xyz
-recovidapp.com
 redditdating.us
 reentercoronagraph.co.kr
 riddoffcovid19.xyz

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -325,7 +325,6 @@ localcoronavirus.com
 lopinavirandritonavircoronavirus.com
 loveinthetimeofcoronavirus.tips
 mapadocoronavirus.com
-marriottcoronadoislandresort.review
 matthewcoronagoldstein.icu
 mexicovida.de
 mmedicalcovid19.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -266,7 +266,6 @@ covid19plasma.com
 covid19project.com
 covid19proof.com
 covid19quickresponse.com
-covid19sickleave.com
 covid19source.com
 covid19symptomchecker.com
 covid19testskit.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -286,7 +286,6 @@ covidquarantine.com
 covidrid.com
 dating4free.us
 dating4sex.us
-dizcorona.com
 doihavecoronaviruscovid19.com
 doihavecovid-19.com
 dopconverion.ru

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -302,7 +302,6 @@ fightcoronavirus.life
 flutter-covid19.firebaseio.com
 fundacionayudacoronavirus.xyz
 gaticovideo.tk
-getcoronavirusalert.com
 getcoronavirusassistance.com
 ggpht.ml
 gocycle.com.au

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -117,7 +117,6 @@ coronavirus-54646.firebaseio.com
 coronavirus-a600f.firebaseio.com
 coronavirus-alert.firebaseio.com
 coronavirus-apps.com
-coronavirus-com.com
 coronavirus-consultancy.com
 coronavirus-consulting.com
 coronavirus-d526b.firebaseio.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -332,7 +332,6 @@ novelcoronavirus.report
 novelcoronavirus.today
 nyccovid19lawyer.com
 officialcoronavirus19.com
-omwgpzbndcoronation.review
 online-coronavirus-268608.firebaseio.com
 onthefx.com
 ovejascoronadas.com

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -312,7 +312,6 @@ i-recovidurl.tk
 i-sharecloud.com
 iamcorona.com
 iamfreeofcovid19.com
-immediatement-stop83894-stopce0da-service-corona7b21f-940c1.info
 impots-covid19.com
 insiderppe.cloudapp.net
 ipv4.login.msa.akadns6.net

--- a/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
+++ b/input-source/domains/bolonobolo/coronavirus-covid19-phishing-domains.txt
@@ -308,7 +308,6 @@ gocycle.com.au
 healing-yui223.com
 hoosiercoronavirus.com
 hovafmd.ddns.net
-hundredcoronas.ru
 i-recovidurl.tk
 i-sharecloud.com
 iamcorona.com


### PR DESCRIPTION
whois additioncoronation.com
No match for domain "ADDITIONCORONATION.COM".
>>> Last update of whois database: 2021-02-14T18:56:34Z <<<

PyFunceble: additioncoronation.com                                                                               INACTIVE    STDLOOKUP