### PR TITLE
Add T.LY to Whitelist

### DIFF
--- a/whitelist.me/whitelist.me
+++ b/whitelist.me/whitelist.me
@@ -165,3 +165,4 @@ www.vaulthealth.com
 www.voipfuture.com
 youtube.com
 zipow.com
+t.ly


### PR DESCRIPTION
T.LY is used as a URL shortener. T.LY actively monitors for malicious URLs. Can T.LY be added to the permanent whitelist group?