### PR TITLE
[skip ci] added bitcoin wallet phishing domain

### DIFF
--- a/input-source/domains/public-domain-additions.txt
+++ b/input-source/domains/public-domain-additions.txt
@@ -4,3 +4,4 @@ copyirghtagencymediacenter.ml
 spiffcoin.net
 dashenopticians.com
 zc11m.csb.app
+restore-metamask.com


### PR DESCRIPTION
target: restore-metamask.com