### PR TITLE
Update whitelist.me

### DIFF
--- a/whitelist.me/whitelist.me
+++ b/whitelist.me/whitelist.me
@@ -732,3 +732,4 @@ youtube.com
 zenodo.org
 zipow.com
 zpr.io
+claritysecure.claritycrm.com


### PR DESCRIPTION
claritysecure.claritycrm.com is marked by the Phishing database. We want this domain to be cleaned from your side.