### PR TITLE
Allowlist phishingquiz.withgoogle.com

### DIFF
--- a/whitelist.me/whitelist.me
+++ b/whitelist.me/whitelist.me
@@ -538,6 +538,7 @@ pearlbanquets.com
 pearlofmyheart.com
 personas.devbam.com
 personas.qa-bam.com
+phishingquiz.withgoogle.com
 phishtank.com
 phishtest.xyz
 photoartstavrinos.com


### PR DESCRIPTION
This is a phishing simulator created by Google.
Google is a horrible company, but they are not phishing, and should not be listed in this database.
[Additionally, other Google domains are allowlisted](https://github.com/mitchellkrogza/Phishing.Database/blob/872bda9c4cc0e3e0a74ff15978627a7e9790c4e6/whitelist.me/whitelist.me#L14), so I believe there is precedent.
Thank you